### PR TITLE
添加 Fedora RISC-V 官方镜像仓库

### DIFF
--- a/roadmap/checklist.md
+++ b/roadmap/checklist.md
@@ -6,7 +6,7 @@
 
 | openEuler                                                    | Arch Linux | Gentoo | Debian | openSUSE | Fedora | Ubuntu | FreeBSD | Deepin | Anolis | openKylin |
 | ------------------------------------------------------------ | ---------- | ------ | ------ | -------- | ------ | ------ | ------- | ------ | ------ | --------- |
-| [iscas仓库](https://mirror.iscas.ac.cn/openeuler-sig-riscv/openEuler-RISC-V/) |            |        |        |          |        |        |         |        |        |   [官方仓库](http://archive.build.openkylin.top/openkylin)        |
+| [iscas仓库](https://mirror.iscas.ac.cn/openeuler-sig-riscv/openEuler-RISC-V/) |            |        |        |          | [官方仓库](https://fedorapeople.org/groups/risc-v/disk-images/)       |        |         |        |        |   [官方仓库](http://archive.build.openkylin.top/openkylin)        |
 
 
 


### PR DESCRIPTION
如题，为`roadmap/checklist.md`添加了 Fedora RISC-V 的官方镜像仓库地址。